### PR TITLE
Create MR for PO when issued to requestor

### DIFF
--- a/app/Http/Controllers/RequestPurchaseOrderController.php
+++ b/app/Http/Controllers/RequestPurchaseOrderController.php
@@ -8,6 +8,7 @@ use App\Models\RequestPurchaseOrder;
 use App\Http\Requests\UpdateRequestPurchaseOrderRequest;
 use App\Http\Resources\RequestPurchaseOrderDetailedResource;
 use App\Http\Resources\RequestPurchaseOrderListingResource;
+use App\Http\Services\PurchaseOrderService;
 
 class RequestPurchaseOrderController extends Controller
 {
@@ -56,9 +57,12 @@ class RequestPurchaseOrderController extends Controller
         $requestPurchaseOrder->update([
             'processing_status' => $newStatus,
         ]);
+        if ($newStatus === PurchaseOrderProcessingStatus::TURNED_OVER) {
+            PurchaseOrderService::createMrrFromPurchaseOrder($requestPurchaseOrder);
+        }
         return (new RequestPurchaseOrderDetailedResource($requestPurchaseOrder))
             ->additional([
-                'message' => 'Purchase Order status updated successfully to ' . $newStatus->value,
+                'message' => "Processing status updated to {$newStatus->value} successfully.",
                 'success' => true,
             ]);
     }

--- a/app/Http/Services/PurchaseOrderService.php
+++ b/app/Http/Services/PurchaseOrderService.php
@@ -36,7 +36,7 @@ class PurchaseOrderService
             $mrr->warehouse_id      = $requestPurchaseOrder->warehouse_id;
             $mrr->reference_no      = TransactionMaterialReceiving::generateNewMrrReferenceNumber();
             $mrr->supplier_id       = $requestPurchaseOrder->supplier_id;
-            $mrr->reference         = $requestPurchaseOrder->po_number;
+            $mrr->reference         = null;
             $mrr->terms_of_payment  = $requestPurchaseOrder->terms_of_payment;
             $mrr->transaction_date  = $requestPurchaseOrder->transaction_date;
             $mrr->metadata          = [

--- a/app/Http/Services/PurchaseOrderService.php
+++ b/app/Http/Services/PurchaseOrderService.php
@@ -3,8 +3,10 @@
 namespace App\Http\Services;
 
 use App\Enums\PurchaseOrderProcessingStatus;
+use App\Enums\ServeStatus;
 use App\Models\RequestCanvassSummary;
 use App\Models\RequestPurchaseOrder;
+use App\Models\TransactionMaterialReceiving;
 use Illuminate\Support\Facades\DB;
 
 class PurchaseOrderService
@@ -27,10 +29,46 @@ class PurchaseOrderService
         });
     }
 
+    public static function createMrrFromPurchaseOrder(RequestPurchaseOrder $requestPurchaseOrder): TransactionMaterialReceiving
+    {
+        return DB::transaction(function () use ($requestPurchaseOrder) {
+            $mrr = new TransactionMaterialReceiving();
+            $mrr->warehouse_id      = $requestPurchaseOrder->warehouse_id;
+            $mrr->reference_no      = TransactionMaterialReceiving::generateNewMrrReferenceNumber();
+            $mrr->supplier_id       = $requestPurchaseOrder->supplier_id;
+            $mrr->reference         = $requestPurchaseOrder->po_number;
+            $mrr->terms_of_payment  = $requestPurchaseOrder->terms_of_payment;
+            $mrr->transaction_date  = $requestPurchaseOrder->transaction_date;
+            $mrr->metadata          = [
+                'is_purchase_order' => true,
+                'po_id' => $requestPurchaseOrder->id,
+                'rs_id' => $requestPurchaseOrder->rs_id,
+            ];
+            $mrr->save();
+            $mappedItems = $requestPurchaseOrder->items->map(fn ($item) => [
+                'transaction_material_receiving_id' => $mrr->id,
+                'item_id'              => $item->item_id,
+                'specification'        => $item->specification,
+                'actual_brand_purchase' => $item->actual_brand_purchase,
+                'requested_quantity'   => $item->quantity,
+                'quantity'             => $item->quantity,
+                'uom_id'               => $item->uom,
+                'unit_price'           => $item->unit_price,
+                'serve_status'         => ServeStatus::UNSERVED,
+                'remarks'              => $item->remarks,
+                'metadata'             => [
+                    'po_id' => $requestPurchaseOrder->id,
+                    'po_item_id' => $item->id,
+                ],
+            ]);
+            $mrr->items()->createMany($mappedItems->toArray());
+            return $mrr;
+        });
+    }
     private static function generatePoNumber()
     {
         $year = now()->year;
-        $lastPO = RequestPurchaseOrder::orderByRaw('SUBSTRING_INDEX(po_number, \'-\', -1) DESC')
+        $lastPO = RequestPurchaseOrder::orderBy('po_number', 'desc')
             ->first();
         $lastRefNo = $lastPO ? collect(explode('-', $lastPO->po_number))->last() : 0;
         $newNumber = str_pad($lastRefNo + 1, 6, '0', STR_PAD_LEFT);

--- a/app/Models/RequestPurchaseOrder.php
+++ b/app/Models/RequestPurchaseOrder.php
@@ -32,7 +32,8 @@ class RequestPurchaseOrder extends Model
         'transaction_date' => 'date',
         'metadata' => 'json',
         'approvals' => 'json',
-        'processing_status' => PurchaseO
+        'processing_status' => PurchaseOrderProcessingStatus::class,
+    ];
     /**
      * ==================================================
      * MODEL RELATIONSHIPS

--- a/app/Models/RequestPurchaseOrder.php
+++ b/app/Models/RequestPurchaseOrder.php
@@ -32,9 +32,7 @@ class RequestPurchaseOrder extends Model
         'transaction_date' => 'date',
         'metadata' => 'json',
         'approvals' => 'json',
-        'processing_status' => PurchaseOrderProcessingStatus::class,
-    ];
-
+        'processing_status' => PurchaseO
     /**
      * ==================================================
      * MODEL RELATIONSHIPS
@@ -44,12 +42,24 @@ class RequestPurchaseOrder extends Model
     {
         return $this->belongsTo(RequestCanvassSummary::class, 'request_canvass_summary_id');
     }
-
+    public function mrr()
+    {
+        return $this->hasOne(TransactionMaterialReceiving::class, 'po_id', 'id');
+    }
     /**
      * ==================================================
      * MODEL ATTRIBUTES
      * ==================================================
      */
+    public function getPriceQuotationAttribute()
+    {
+        return $this->requestCanvassSummary?->priceQuotation;
+    }
+
+    public function getRequisitionSlipAttribute()
+    {
+        return $this->priceQuotation?->requestProcurement?->requisitionSlip;
+    }
 
     public function getIsPrepaymentAttribute(): bool
     {
@@ -57,7 +67,6 @@ class RequestPurchaseOrder extends Model
             ? strtolower($this->requestCanvassSummary->terms_of_payment) === 'prepayment in full'
             : false;
     }
-
     public function getProcessingFlowAttribute()
     {
         return [
@@ -90,15 +99,50 @@ class RequestPurchaseOrder extends Model
             PurchaseOrderProcessingStatus::SERVED->value => [],
         ];
     }
-
     public function getAllowedNextStatusesAttribute(): array
     {
         $workflow = $this->processing_flow;
         return $workflow[$this->processing_status->value] ?? [];
     }
-
     public function getIsServedAttribute(): bool
     {
         return $this->processing_status === PurchaseOrderProcessingStatus::SERVED;
+    }
+    public function getWarehouseIdAttribute()
+    {
+        return $this->requisitionSlip?->warehouse_id;
+    }
+    public function getSupplierIdAttribute()
+    {
+        return $this->priceQuotation?->supplier_id;
+    }
+    public function getTermsOfPaymentAttribute()
+    {
+        return $this->requestCanvassSummary?->terms_of_payment;
+    }
+    public function getRsIdAttribute()
+    {
+        return $this->requisitionSlip?->id;
+    }
+
+    public function getItemsAttribute()
+    {
+        $requisitionItems = $this->requisitionSlip?->items ?? collect();
+        $pqItems          = $this->priceQuotation?->items ?? collect();
+        $csItems          = $this->requestCanvassSummary?->items ?? collect();
+        return $requisitionItems->map(function ($reqItem) use ($pqItems, $csItems) {
+            $pqItem = $pqItems->firstWhere('item_id', $reqItem->item_id);
+            $csItem = $csItems->firstWhere('item_id', $reqItem->item_id);
+            return (object) [
+                'id'                   => $reqItem->id,
+                'item_id'              => $reqItem->item_id,
+                'specification'        => $reqItem->specification,
+                'quantity'             => $reqItem->quantity,
+                'uom'                  => $reqItem->unit,
+                'remarks'              => $reqItem->remarks,
+                'actual_brand_purchase' => $pqItem?->actual_brand,
+                'unit_price'           => $csItem?->unit_price,
+            ];
+        });
     }
 }

--- a/app/Models/TransactionMaterialReceiving.php
+++ b/app/Models/TransactionMaterialReceiving.php
@@ -72,4 +72,13 @@ class TransactionMaterialReceiving extends Model
     {
         return $this->items->where('acceptance_status', '=', ReceivingAcceptanceStatus::PENDING->value)->isEmpty() ? ServeStatus::SERVED->value : ServeStatus::UNSERVED->value;
     }
+    public static function generateNewMrrReferenceNumber()
+    {
+        $year = now()->year;
+        $lastMRR = TransactionMaterialReceiving::orderByRaw('SUBSTRING_INDEX(reference_no, \'-\', -1) DESC')
+            ->first();
+        $lastRefNo = $lastMRR ? collect(explode('-', $lastMRR->reference_no))->last() : 0;
+        $newNumber = str_pad($lastRefNo + 1, 6, '0', STR_PAD_LEFT);
+        return "MRR-{$year}-{$newNumber}";
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically creates a Material Receiving Report (MRR) when a purchase order is turned over.
  - Auto-generates standardized MRR reference numbers (MRR-YYYY-XXXXXX).

- Enhancements
  - Purchase order details now expose more related information (supplier, warehouse, terms, requisition slip, consolidated items) for easier viewing.
  - Status update confirmation message is clearer and includes the new status value.

- Documentation
  - None

- Tests
  - None

<!-- end of auto-generated comment: release notes by coderabbit.ai -->